### PR TITLE
Time budget and call depth max

### DIFF
--- a/connector/connector.go
+++ b/connector/connector.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/microbus-io/fabric/rand"
 	"github.com/nats-io/nats.go"
@@ -30,8 +31,10 @@ type Connector struct {
 	subsLock     sync.Mutex
 	started      bool
 
-	reqs     map[string]chan *http.Response
-	reqsLock sync.Mutex
+	reqs         map[string]chan *http.Response
+	reqsLock     sync.Mutex
+	networkHop   time.Duration
+	maxCallDepth int
 
 	configs    map[string]*config
 	configLock sync.Mutex
@@ -40,9 +43,11 @@ type Connector struct {
 // NewConnector constructs a new Connector.
 func NewConnector() *Connector {
 	c := &Connector{
-		id:      strings.ToLower(rand.AlphaNum32(10)),
-		reqs:    map[string]chan *http.Response{},
-		configs: map[string]*config{},
+		id:           strings.ToLower(rand.AlphaNum32(10)),
+		reqs:         map[string]chan *http.Response{},
+		configs:      map[string]*config{},
+		networkHop:   250 * time.Millisecond,
+		maxCallDepth: 64,
 	}
 	return c
 }

--- a/frame/frame.go
+++ b/frame/frame.go
@@ -1,0 +1,137 @@
+package frame
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const (
+	HeaderPrefix     = "Microbus-"
+	HeaderMsgId      = HeaderPrefix + "Msg-Id"
+	HeaderFromHost   = HeaderPrefix + "From-Host"
+	HeaderFromId     = HeaderPrefix + "From-Id"
+	HeaderTimeBudget = HeaderPrefix + "Time-Budget"
+	HeaderCallDepth  = HeaderPrefix + "Call-Depth"
+)
+
+// Frame is a utility class that helps with manipulating the control headers
+type Frame struct {
+	h http.Header
+}
+
+// Of creates a new frame for the headers of the HTTP request, response or response writer
+func Of(r any) Frame {
+	var h http.Header
+	switch v := r.(type) {
+	case *http.Request:
+		h = v.Header
+	case *http.Response:
+		h = v.Header
+	case http.ResponseWriter:
+		h = v.Header()
+	case http.Header:
+		h = v
+	case context.Context:
+		h, _ = v.Value(ContextKey).(http.Header)
+		if h == nil {
+			h = make(http.Header)
+		}
+	}
+	return Frame{h}
+}
+
+// FromHost is the host name of the microservice that made the request or reply
+func (f Frame) FromHost() string {
+	return f.h.Get(HeaderFromHost)
+}
+
+// SetFromHost sets the host name of the microservice that is making the request or reply
+func (f Frame) SetFromHost(host string) {
+	if host == "" {
+		f.h.Del(HeaderFromHost)
+	} else {
+		f.h.Set(HeaderFromHost, host)
+	}
+}
+
+// FromID is the unique ID of the instance of the microservice that made the request or reply
+func (f Frame) FromID() string {
+	return f.h.Get(HeaderFromId)
+}
+
+// SetFromID sets the unique ID of the instance of the microservice that is making the request or reply
+func (f Frame) SetFromID(id string) {
+	if id == "" {
+		f.h.Del(HeaderFromId)
+	} else {
+		f.h.Set(HeaderFromId, id)
+	}
+}
+
+// MessageID is the unique ID given to each HTTP message and its reply
+func (f Frame) MessageID() string {
+	return f.h.Get(HeaderMsgId)
+}
+
+// SetMessageID sets the unique ID given to each HTTP message or reply
+func (f Frame) SetMessageID(id string) {
+	if id == "" {
+		f.h.Del(HeaderMsgId)
+	} else {
+		f.h.Set(HeaderMsgId, id)
+	}
+}
+
+// CallDepth is the depth of the call stack beginning at the original request
+func (f Frame) CallDepth() int {
+	v := f.h.Get(HeaderCallDepth)
+	if v == "" {
+		return 0
+	}
+	depth, err := strconv.Atoi(v)
+	if err != nil {
+		return 0
+	}
+	return depth
+}
+
+// SetCallDepth sets the depth of the call stack beginning at the original request
+func (f Frame) SetCallDepth(depth int) {
+	if depth == 0 {
+		f.h.Del(HeaderCallDepth)
+	} else {
+		f.h.Set(HeaderCallDepth, strconv.Itoa(depth))
+	}
+}
+
+// TimeBudget is the duration budgeted for the request to complete.
+// !ok indicates no time budget is specified
+func (f Frame) TimeBudget() (budget time.Duration, ok bool) {
+	v := f.h.Get(HeaderTimeBudget)
+	if v == "" {
+		return 0, false
+	}
+	ms, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, false
+	}
+	return time.Millisecond * time.Duration(ms), true
+}
+
+// SetTimeBudget budgets a duration for the request to complete.
+// A value of zero or less is interpreted as no time budget
+func (f Frame) SetTimeBudget(budget time.Duration) {
+	ms := int(budget.Milliseconds())
+	if ms <= 0 {
+		f.h.Del(HeaderTimeBudget)
+	} else {
+		f.h.Set(HeaderTimeBudget, strconv.Itoa(ms))
+	}
+}
+
+type contextKeyType struct{}
+
+// ContextKey is used to store the request headers in a context
+var ContextKey = contextKeyType{}

--- a/frame/frame_test.go
+++ b/frame/frame_test.go
@@ -1,0 +1,82 @@
+package frame
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFrame_Of(t *testing.T) {
+	t.Parallel()
+
+	// http.Request
+	httpRequest, err := http.NewRequest("GET", "https://www.example.com", nil)
+	assert.NoError(t, err)
+	httpRequest.Header.Set(HeaderMsgId, "123")
+	assert.Equal(t, "123", Of(httpRequest).MessageID())
+
+	// httptest.ResponseRecorder and http.Response
+	httpRecorder := httptest.NewRecorder()
+	httpRecorder.Header().Set(HeaderMsgId, "123")
+	assert.Equal(t, "123", Of(httpRecorder).MessageID())
+	httpResponse := httpRecorder.Result()
+	assert.Equal(t, "123", Of(httpResponse).MessageID())
+
+	// http.Header
+	hdr := make(http.Header)
+	hdr.Set(HeaderMsgId, "123")
+	assert.Equal(t, "123", Of(hdr).MessageID())
+
+	// context.Context
+	ctx := context.WithValue(context.Background(), ContextKey, hdr)
+	assert.Equal(t, "123", Of(ctx).MessageID())
+
+	// Empty context.Context should not panic
+	assert.Equal(t, "", Of(context.Background()).MessageID())
+}
+
+func TestFrame_GetSet(t *testing.T) {
+	t.Parallel()
+
+	f := Of(make(http.Header))
+
+	assert.Equal(t, 0, f.CallDepth())
+	f.SetCallDepth(123)
+	assert.Equal(t, 123, f.CallDepth())
+	f.SetCallDepth(0)
+	assert.Equal(t, 0, f.CallDepth())
+
+	assert.Equal(t, "", f.FromHost())
+	f.SetFromHost("www.example.com")
+	assert.Equal(t, "www.example.com", f.FromHost())
+	f.SetFromHost("")
+	assert.Equal(t, "", f.FromHost())
+
+	assert.Equal(t, "", f.FromID())
+	f.SetFromID("1234567890")
+	assert.Equal(t, "1234567890", f.FromID())
+	f.SetFromID("")
+	assert.Equal(t, "", f.FromID())
+
+	assert.Equal(t, "", f.MessageID())
+	f.SetMessageID("1234567890")
+	assert.Equal(t, "1234567890", f.MessageID())
+	f.SetMessageID("")
+	assert.Equal(t, "", f.MessageID())
+
+	budget, ok := f.TimeBudget()
+	assert.False(t, ok)
+	assert.Equal(t, time.Duration(0), budget)
+	f.SetTimeBudget(123 * time.Second)
+	budget, ok = f.TimeBudget()
+	assert.True(t, ok)
+	assert.Equal(t, 123*time.Second, budget)
+	f.SetTimeBudget(0)
+	budget, ok = f.TimeBudget()
+	assert.False(t, ok)
+	assert.Equal(t, time.Duration(0), budget)
+}

--- a/pub/doc.go
+++ b/pub/doc.go
@@ -1,0 +1,5 @@
+/*
+Package pub is used for the publishing of requests.
+It contains the options to use in Connector.Publish
+*/
+package pub

--- a/pub/option.go
+++ b/pub/option.go
@@ -1,0 +1,100 @@
+package pub
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"strings"
+	"time"
+)
+
+// Option is used to construct a request
+type Option func(req *Request) error
+
+// Method sets the method of the request
+func Method(method string) Option {
+	method = strings.ToUpper(method)
+	return func(req *Request) error {
+		req.method = method
+		return nil
+	}
+}
+
+// URL sets the URL of the request
+func URL(url string) Option {
+	return func(req *Request) error {
+		req.url = url
+		return nil
+	}
+}
+
+// GET sets the method and URL of the request
+func GET(url string) Option {
+	return func(req *Request) error {
+		req.method = "GET"
+		req.url = url
+		return nil
+	}
+}
+
+// POST sets the method and URL of the request
+func POST(url string) Option {
+	return func(req *Request) error {
+		req.method = "POST"
+		req.url = url
+		return nil
+	}
+}
+
+// Header add the header to the request.
+// The same header may have multiple values
+func Header(name, value string) Option {
+	return func(req *Request) error {
+		if value != "" {
+			req.headers.Add(name, value)
+		}
+		return nil
+	}
+}
+
+// Body sets the body of the request.
+// Arguments of type io.Reader, []byte and string are serialized in binary form.
+// All other types are serialized as JSON
+func Body(body any) Option {
+	return func(req *Request) error {
+		if body == nil {
+			return nil
+		}
+		switch v := body.(type) {
+		case io.Reader:
+			req.body = v
+		case []byte:
+			req.body = bytes.NewReader(v)
+		case string:
+			req.body = strings.NewReader(v)
+		default:
+			j, err := json.Marshal(body)
+			if err != nil {
+				return err
+			}
+			req.body = bytes.NewReader(j)
+			req.headers.Set("Content-Type", "application/json")
+		}
+		return nil
+	}
+}
+
+// TimeBudget sets the time budget of the request.
+// Once a time budget is set, it is only possible to shorten it, not extend it
+func TimeBudget(budget time.Duration) Option {
+	if budget < 0 {
+		budget = 0
+	}
+	return func(req *Request) error {
+		if !req.hasBudget || req.timeBudget > budget {
+			req.hasBudget = true
+			req.timeBudget = budget
+		}
+		return nil
+	}
+}

--- a/pub/request.go
+++ b/pub/request.go
@@ -1,0 +1,48 @@
+package pub
+
+import (
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/microbus-io/fabric/frame"
+)
+
+// Request is used to construct an HTTP request that can be sent over the Microbus
+type Request struct {
+	method     string
+	url        string
+	headers    http.Header
+	body       io.Reader
+	timeBudget time.Duration
+	hasBudget  bool
+}
+
+// NewRequest constructs a new request from the provided options
+func NewRequest(options ...Option) (*Request, error) {
+	req := &Request{
+		headers: make(http.Header),
+	}
+	for _, opt := range options {
+		err := opt(req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return req, nil
+}
+
+// ToHTTP constructs an HTTP request given the properties set for this request
+func (req *Request) ToHTTP() (*http.Request, error) {
+	httpReq, err := http.NewRequest(req.method, req.url, req.body)
+	if err != nil {
+		return nil, err
+	}
+	for name, value := range req.headers {
+		httpReq.Header[name] = value
+	}
+	if req.hasBudget {
+		frame.Of(httpReq).SetTimeBudget(req.timeBudget)
+	}
+	return httpReq, nil
+}

--- a/pub/request_test.go
+++ b/pub/request_test.go
@@ -1,0 +1,135 @@
+package pub
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/microbus-io/fabric/frame"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPub_MethodAndURL(t *testing.T) {
+	t.Parallel()
+
+	// GET
+	req, err := NewRequest([]Option{
+		GET("https://www.example.com"),
+	}...)
+	assert.NoError(t, err)
+	httpReq, err := req.ToHTTP()
+	assert.NoError(t, err)
+	assert.Equal(t, "GET", httpReq.Method)
+	assert.Equal(t, "www.example.com", httpReq.URL.Hostname())
+
+	// POST
+	req, err = NewRequest([]Option{
+		POST("https://www.example.com/path"),
+	}...)
+	assert.NoError(t, err)
+	httpReq, err = req.ToHTTP()
+	assert.NoError(t, err)
+	assert.Equal(t, "POST", httpReq.Method)
+	assert.Equal(t, "www.example.com", httpReq.URL.Hostname())
+	assert.Equal(t, "/path", httpReq.URL.Path)
+
+	// Any method
+	req, err = NewRequest([]Option{
+		Method("Delete"), // Mixed case
+		URL("https://www.example.com"),
+	}...)
+	assert.NoError(t, err)
+	httpReq, err = req.ToHTTP()
+	assert.NoError(t, err)
+	assert.Equal(t, "DELETE", httpReq.Method)
+	assert.Equal(t, "www.example.com", httpReq.URL.Hostname())
+}
+
+func TestPub_Header(t *testing.T) {
+	t.Parallel()
+
+	req, err := NewRequest([]Option{
+		GET("https://www.example.com"),
+		Header("Content-Type", "text/html"),
+		Header("X-SOMETHING", "Else"), // Uppercase
+	}...)
+	assert.NoError(t, err)
+	httpReq, err := req.ToHTTP()
+	assert.NoError(t, err)
+	assert.Equal(t, "text/html", httpReq.Header.Get("Content-Type"))
+	assert.Equal(t, "Else", httpReq.Header.Get("X-Something"))
+}
+
+func TestPub_Body(t *testing.T) {
+	t.Parallel()
+
+	// String
+	req, err := NewRequest([]Option{
+		GET("https://www.example.com"),
+		Body("Hello World"),
+	}...)
+	assert.NoError(t, err)
+	httpReq, err := req.ToHTTP()
+	assert.NoError(t, err)
+	body, err := io.ReadAll(httpReq.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, "Hello World", string(body))
+
+	// []byte
+	req, err = NewRequest([]Option{
+		GET("https://www.example.com"),
+		Body([]byte("Hello World")),
+	}...)
+	assert.NoError(t, err)
+	httpReq, err = req.ToHTTP()
+	assert.NoError(t, err)
+	body, err = io.ReadAll(httpReq.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, "Hello World", string(body))
+
+	// io.Reader
+	req, err = NewRequest([]Option{
+		GET("https://www.example.com"),
+		Body(bytes.NewReader([]byte("Hello World"))),
+	}...)
+	assert.NoError(t, err)
+	httpReq, err = req.ToHTTP()
+	assert.NoError(t, err)
+	body, err = io.ReadAll(httpReq.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, "Hello World", string(body))
+
+	// JSON
+	j := struct {
+		S string `json:"s"`
+		I int    `json:"i"`
+	}{"ABC", 123}
+	req, err = NewRequest([]Option{
+		GET("https://www.example.com"),
+		Body(j),
+	}...)
+	assert.NoError(t, err)
+	httpReq, err = req.ToHTTP()
+	assert.NoError(t, err)
+	body, err = io.ReadAll(httpReq.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"s":"ABC","i":123}`, string(body))
+}
+
+func TestPub_TimeBudget(t *testing.T) {
+	t.Parallel()
+
+	req, err := NewRequest([]Option{
+		GET("https://www.example.com"),
+		TimeBudget(30 * time.Second),
+		TimeBudget(20 * time.Second), // Shortest
+		TimeBudget(40 * time.Second),
+	}...)
+	assert.NoError(t, err)
+	httpReq, err := req.ToHTTP()
+	assert.NoError(t, err)
+	budget, ok := frame.Of(httpReq).TimeBudget()
+	assert.True(t, ok)
+	assert.Equal(t, 20*time.Second, budget)
+}


### PR DESCRIPTION
Ingress proxy to set time budget of 20sec (configurable)
Propagate time budget via headers and context
Frame package to help read/write control headers and define header name constants
Connector.Publish using the options pattern