### PR TITLE
Respond with status code of error

### DIFF
--- a/connector/subscribe.go
+++ b/connector/subscribe.go
@@ -318,7 +318,11 @@ func (c *Connector) onRequest(msg *nats.Msg, s *sub.Subscription) error {
 			if err != nil {
 				return errors.Trace(err)
 			}
-			httpRecorder.WriteHeader(http.StatusInternalServerError)
+			statusCode := errors.Convert(handlerErr).StatusCode
+			if statusCode == 0 {
+				statusCode = http.StatusInternalServerError
+			}
+			httpRecorder.WriteHeader(statusCode)
 			httpRecorder.Write(body)
 		}
 	}


### PR DESCRIPTION
When processing a request, if the handler returns an error, use its status code for the status code of the response.